### PR TITLE
Search by seed creator name and detect in-app browsers

### DIFF
--- a/components/auth/sign-in-button.tsx
+++ b/components/auth/sign-in-button.tsx
@@ -2,8 +2,24 @@
 
 import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
+import { useIsInAppBrowser } from "@/lib/hooks/use-is-in-app-browser";
 
 export function SignInButton() {
+  const isInAppBrowser = useIsInAppBrowser();
+
+  if (isInAppBrowser) {
+    return (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+        <p className="font-medium">Open in your browser to sign in</p>
+        <p className="mt-1 text-amber-700">
+          Google sign-in doesn&apos;t work inside app browsers. Tap the menu
+          (&hellip;) and choose &ldquo;Open in Chrome&rdquo; or &ldquo;Open in
+          Safari&rdquo;.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <Button type="button" onClick={() => signIn("google")} variant="default">
       Sign in with Google

--- a/lib/db/queries/seeds.ts
+++ b/lib/db/queries/seeds.ts
@@ -38,7 +38,11 @@ function buildVisibilityFilter(options: {
   if (options.search) {
     const pattern = `%${options.search}%`;
     conditions.push(
-      or(ilike(seeds.name, pattern), ilike(seeds.summary, pattern)),
+      or(
+        ilike(seeds.name, pattern),
+        ilike(seeds.summary, pattern),
+        ilike(users.name, pattern),
+      ),
     );
   }
 
@@ -86,6 +90,7 @@ export async function getApprovedSeeds(options: {
       db
         .select(selectFields)
         .from(seeds)
+        .innerJoin(users, eq(seeds.createdBy, users.id))
         .innerJoin(seedSupports, eq(seeds.id, seedSupports.seedId))
         .where(mineWhere)
         .orderBy(desc(seedSupports.createdAt))
@@ -94,6 +99,7 @@ export async function getApprovedSeeds(options: {
       db
         .select({ count: count() })
         .from(seeds)
+        .innerJoin(users, eq(seeds.createdBy, users.id))
         .innerJoin(seedSupports, eq(seeds.id, seedSupports.seedId))
         .where(mineWhere),
     ]);
@@ -110,11 +116,16 @@ export async function getApprovedSeeds(options: {
     db
       .select(selectFields)
       .from(seeds)
+      .innerJoin(users, eq(seeds.createdBy, users.id))
       .where(where)
       .orderBy(...orderBy)
       .limit(SEEDS_PER_PAGE)
       .offset(offset),
-    db.select({ count: count() }).from(seeds).where(where),
+    db
+      .select({ count: count() })
+      .from(seeds)
+      .innerJoin(users, eq(seeds.createdBy, users.id))
+      .where(where),
   ]);
 
   return {
@@ -211,5 +222,6 @@ export async function getAllSeedsForMap(options: {
       locationLng: seeds.locationLng,
     })
     .from(seeds)
+    .innerJoin(users, eq(seeds.createdBy, users.id))
     .where(where);
 }

--- a/lib/hooks/use-is-in-app-browser.ts
+++ b/lib/hooks/use-is-in-app-browser.ts
@@ -1,0 +1,26 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * In-app browser tokens from Facebook, Instagram, Messenger, LinkedIn,
+ * Twitter/X, Snapchat, TikTok, Line, WeChat, and generic WebView markers.
+ */
+const IN_APP_PATTERN =
+  /FBAN|FBAV|FB_IAB|Instagram|Messenger|LinkedInApp|Twitter|Snapchat|TikTok|Line|MicroMessenger|WebView|wv\b/i;
+
+function getSnapshot(): boolean {
+  return IN_APP_PATTERN.test(navigator.userAgent);
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function subscribe(_cb: () => void): () => void {
+  // User agent never changes — nothing to subscribe to.
+  return () => {};
+}
+
+export function useIsInAppBrowser(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## Summary
- **Search by creator name (#10):** Homepage search now matches against the seed creator's name (first/last) in addition to seed title and summary, so searching "David" surfaces David's projects even if you don't know the seed name.
- **In-app browser detection (#11):** When a user opens the site in Facebook Messenger (or other in-app browsers), the sign-in button is replaced with a friendly prompt to open in Chrome/Safari, avoiding the Google OAuth `disallowed_useragent` error.

Closes #10
Closes #11

## Test plan
- [x] Search for a user's first or last name on the homepage — their seeds should appear
- [x] Search by seed title and summary still works as before
- [ ] Open the site in Facebook Messenger's in-app browser — sign-in button should be replaced with an "Open in your browser" message
- [ ] Open the site in a normal browser — sign-in button works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)