### PR TITLE
Allow seed creators to set a cover photo

### DIFF
--- a/app/seeds/[id]/page.tsx
+++ b/app/seeds/[id]/page.tsx
@@ -225,9 +225,9 @@ export default async function SeedPage(props: {
                 priority
               />
             </a>
-          ) : (
-            canEdit && <SeedImageGenerator seedId={seed.id} />
-          )}
+          ) : null}
+          {/* Always generate AI illustration if missing, even when cover photo is set */}
+          {!seed.imageUrl && canEdit && <SeedImageGenerator seedId={seed.id} />}
         </div>
       </div>
 

--- a/app/seeds/[id]/page.tsx
+++ b/app/seeds/[id]/page.tsx
@@ -191,7 +191,24 @@ export default async function SeedPage(props: {
 
         {/* Image — top right on desktop, below on mobile */}
         <div className="flex flex-col gap-4">
-          {seed.imageUrl ? (
+          {seed.coverPhotoUrl ? (
+            <a
+              href={seed.coverPhotoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block overflow-hidden rounded-2xl"
+            >
+              <Image
+                src={seed.coverPhotoUrl}
+                alt={seed.name}
+                width={720}
+                height={720}
+                className="h-auto w-full"
+                sizes="(max-width: 768px) 100vw, 360px"
+                priority
+              />
+            </a>
+          ) : seed.imageUrl ? (
             <a
               href={seed.imageUrl}
               target="_blank"
@@ -214,31 +231,54 @@ export default async function SeedPage(props: {
         </div>
       </div>
 
-      {/* Photos */}
-      {seed.photos.length > 0 && (
-        <div className="mb-8">
-          <h3 className="mb-3 text-sm font-semibold">Photos</h3>
-          <div className="grid grid-cols-3 gap-3">
-            {seed.photos.map((url, i) => (
-              <a
-                key={url}
-                href={url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="relative block aspect-square overflow-hidden rounded-lg"
-              >
-                <Image
-                  src={url}
-                  alt={`${seed.name} photo ${i + 1}`}
-                  fill
-                  className="object-cover"
-                  sizes="(max-width: 768px) 33vw, 280px"
-                />
-              </a>
-            ))}
+      {/* Photos — exclude cover (shown above), include AI illustration when cover is a user photo */}
+      {(() => {
+        const displayPhotos = seed.coverPhotoUrl
+          ? seed.photos.filter((url) => url !== seed.coverPhotoUrl)
+          : seed.photos;
+        const showAiInGrid = seed.coverPhotoUrl && seed.imageUrl;
+        if (displayPhotos.length === 0 && !showAiInGrid) return null;
+        return (
+          <div className="mb-8">
+            <h3 className="mb-3 text-sm font-semibold">Photos</h3>
+            <div className="grid grid-cols-3 gap-3">
+              {displayPhotos.map((url, i) => (
+                <a
+                  key={url}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative block aspect-square overflow-hidden rounded-lg"
+                >
+                  <Image
+                    src={url}
+                    alt={`${seed.name} photo ${i + 1}`}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 768px) 33vw, 280px"
+                  />
+                </a>
+              ))}
+              {showAiInGrid && (
+                <a
+                  href={seed.imageUrl!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative block aspect-square overflow-hidden rounded-lg"
+                >
+                  <Image
+                    src={seed.imageUrl!}
+                    alt={`${seed.name} illustration`}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 768px) 33vw, 280px"
+                  />
+                </a>
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Map — full width */}
       {hasLocation && (

--- a/app/seeds/[id]/page.tsx
+++ b/app/seeds/[id]/page.tsx
@@ -264,7 +264,7 @@ export default async function SeedPage(props: {
                   href={seed.imageUrl!}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="relative block aspect-square overflow-hidden rounded-lg"
+                  className="relative block aspect-3/4 overflow-hidden rounded-lg"
                 >
                   <Image
                     src={seed.imageUrl!}

--- a/app/seeds/[id]/page.tsx
+++ b/app/seeds/[id]/page.tsx
@@ -231,13 +231,12 @@ export default async function SeedPage(props: {
         </div>
       </div>
 
-      {/* Photos — exclude cover (shown above), include AI illustration when cover is a user photo */}
+      {/* Photos — exclude cover photo (already shown as primary) */}
       {(() => {
         const displayPhotos = seed.coverPhotoUrl
           ? seed.photos.filter((url) => url !== seed.coverPhotoUrl)
           : seed.photos;
-        const showAiInGrid = seed.coverPhotoUrl && seed.imageUrl;
-        if (displayPhotos.length === 0 && !showAiInGrid) return null;
+        if (displayPhotos.length === 0) return null;
         return (
           <div className="mb-8">
             <h3 className="mb-3 text-sm font-semibold">Photos</h3>
@@ -259,22 +258,6 @@ export default async function SeedPage(props: {
                   />
                 </a>
               ))}
-              {showAiInGrid && (
-                <a
-                  href={seed.imageUrl!}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="relative block aspect-3/4 overflow-hidden rounded-lg"
-                >
-                  <Image
-                    src={seed.imageUrl!}
-                    alt={`${seed.name} illustration`}
-                    fill
-                    className="object-cover"
-                    sizes="(max-width: 768px) 33vw, 280px"
-                  />
-                </a>
-              )}
             </div>
           </div>
         );
@@ -378,6 +361,27 @@ export default async function SeedPage(props: {
               </a>
             </Button>
           )}
+        </div>
+      )}
+
+      {/* AI illustration — shown at bottom when a user photo is the cover */}
+      {seed.coverPhotoUrl && seed.imageUrl && (
+        <div className="mt-12 flex justify-center">
+          <a
+            href={seed.imageUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block max-w-xs overflow-hidden rounded-2xl"
+          >
+            <Image
+              src={seed.imageUrl}
+              alt={`${seed.name} illustration`}
+              width={360}
+              height={480}
+              className="h-auto w-full"
+              sizes="320px"
+            />
+          </a>
         </div>
       )}
     </div>

--- a/components/forms/photo-upload.tsx
+++ b/components/forms/photo-upload.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from "react";
 import Image from "next/image";
 import { upload } from "@vercel/blob/client";
-import { ImagePlus, Loader2, X } from "lucide-react";
+import { Check, ImagePlus, Loader2, Star, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 
@@ -13,9 +13,16 @@ const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
 interface PhotoUploadProps {
   photos: string[];
   onPhotosChange: (photos: string[]) => void;
+  coverPhotoUrl: string | null;
+  onCoverPhotoChange: (url: string | null) => void;
 }
 
-export function PhotoUpload({ photos, onPhotosChange }: PhotoUploadProps) {
+export function PhotoUpload({
+  photos,
+  onPhotosChange,
+  coverPhotoUrl,
+  onCoverPhotoChange,
+}: PhotoUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -62,6 +69,9 @@ export function PhotoUpload({ photos, onPhotosChange }: PhotoUploadProps) {
   }
 
   function removePhoto(index: number) {
+    if (photos[index] === coverPhotoUrl) {
+      onCoverPhotoChange(null);
+    }
     onPhotosChange(photos.filter((_, i) => i !== index));
   }
 
@@ -77,24 +87,44 @@ export function PhotoUpload({ photos, onPhotosChange }: PhotoUploadProps) {
 
       {photos.length > 0 && (
         <div className="flex flex-wrap gap-3">
-          {photos.map((url, index) => (
-            <div key={url} className="group relative">
-              <Image
-                src={url}
-                alt={`Photo ${index + 1}`}
-                width={120}
-                height={120}
-                className="size-28 rounded-lg border object-cover"
-              />
-              <button
-                type="button"
-                onClick={() => removePhoto(index)}
-                className="absolute -right-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-sm transition-all hover:bg-muted-foreground hover:text-background"
-              >
-                <X className="size-3" />
-              </button>
-            </div>
-          ))}
+          {photos.map((url, index) => {
+            const isCover = url === coverPhotoUrl;
+            return (
+              <div key={url} className="group relative">
+                <Image
+                  src={url}
+                  alt={`Photo ${index + 1}`}
+                  width={120}
+                  height={120}
+                  className={`size-28 rounded-lg border-2 object-cover ${isCover ? "border-primary" : "border-border"}`}
+                />
+                {isCover && (
+                  <span className="absolute bottom-1 left-1 flex items-center gap-0.5 rounded bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">
+                    <Check className="size-2.5" />
+                    Cover
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => removePhoto(index)}
+                  className="absolute -right-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-sm transition-all hover:bg-muted-foreground hover:text-background"
+                >
+                  <X className="size-3" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onCoverPhotoChange(isCover ? null : url)}
+                  title={isCover ? "Remove as cover" : "Use as cover"}
+                  className={`absolute -left-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border shadow-sm transition-all ${isCover ? "border-primary bg-primary text-primary-foreground" : "border-border bg-background text-muted-foreground hover:bg-muted-foreground hover:text-background"}`}
+                >
+                  <Star
+                    className="size-3"
+                    fill={isCover ? "currentColor" : "none"}
+                  />
+                </button>
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/components/forms/photo-upload.tsx
+++ b/components/forms/photo-upload.tsx
@@ -6,6 +6,7 @@ import { upload } from "@vercel/blob/client";
 import { Check, ImagePlus, Loader2, Star, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
 const MAX_PHOTOS = 5;
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
@@ -96,7 +97,10 @@ export function PhotoUpload({
                   alt={`Photo ${index + 1}`}
                   width={120}
                   height={120}
-                  className={`size-28 rounded-lg border-2 object-cover ${isCover ? "border-primary" : "border-border"}`}
+                  className={cn(
+                    "size-28 rounded-lg border-2 object-cover",
+                    isCover ? "border-primary" : "border-border",
+                  )}
                 />
                 {isCover && (
                   <span className="absolute bottom-1 left-1 flex items-center gap-0.5 rounded bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">
@@ -115,7 +119,12 @@ export function PhotoUpload({
                   type="button"
                   onClick={() => onCoverPhotoChange(isCover ? null : url)}
                   title={isCover ? "Remove as cover" : "Use as cover"}
-                  className={`absolute -left-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border shadow-sm transition-all ${isCover ? "border-primary bg-primary text-primary-foreground" : "border-border bg-background text-muted-foreground hover:bg-muted-foreground hover:text-background"}`}
+                  className={cn(
+                    "absolute -left-1.5 -top-1.5 flex size-5 items-center justify-center rounded-full border shadow-sm transition-all",
+                    isCover
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-background text-muted-foreground hover:bg-muted-foreground hover:text-background",
+                  )}
                 >
                   <Star
                     className="size-3"

--- a/components/forms/seed-form.tsx
+++ b/components/forms/seed-form.tsx
@@ -101,6 +101,9 @@ export function SeedForm({ seed, planterName }: SeedFormProps) {
     seed?.imageUrl ?? null,
   );
   const [photos, setPhotos] = useState<string[]>(seed?.photos ?? []);
+  const [coverPhotoUrl, setCoverPhotoUrl] = useState<string | null>(
+    seed?.coverPhotoUrl ?? null,
+  );
 
   const isSignedIn = !!session?.user;
 
@@ -129,6 +132,7 @@ export function SeedForm({ seed, planterName }: SeedFormProps) {
       budget: budget || undefined,
       obstacles: obstacles || undefined,
       photos,
+      coverPhotoUrl: coverPhotoUrl ?? null,
     };
 
     startTransition(async () => {
@@ -334,7 +338,12 @@ export function SeedForm({ seed, planterName }: SeedFormProps) {
         </div>
 
         {/* Photos */}
-        <PhotoUpload photos={photos} onPhotosChange={setPhotos} />
+        <PhotoUpload
+          photos={photos}
+          onPhotosChange={setPhotos}
+          coverPhotoUrl={coverPhotoUrl}
+          onCoverPhotoChange={setCoverPhotoUrl}
+        />
 
         {/* Illustration (edit mode only) */}
         {seed && (

--- a/components/forms/seed-form.tsx
+++ b/components/forms/seed-form.tsx
@@ -353,7 +353,10 @@ export function SeedForm({ seed, planterName }: SeedFormProps) {
               Illustration
             </Label>
             <p className="text-xs text-muted-foreground">
-              Improve the image by editing your description
+              Improve the automatically generated image by editing your
+              description. The more descriptive your idea, the better the
+              illustration. This will be your cover photo unless you star an
+              image you upload.
             </p>
             {imageUrl ? (
               <a

--- a/lib/actions/seeds.ts
+++ b/lib/actions/seeds.ts
@@ -26,6 +26,7 @@ function seedFormToDbFields(values: SeedFormValues) {
     budget: values.budget ?? null,
     obstacles: values.obstacles ?? null,
     photos: values.photos,
+    coverPhotoUrl: values.coverPhotoUrl ?? null,
   };
 }
 

--- a/lib/db/migrations/0002_cuddly_quasar.sql
+++ b/lib/db/migrations/0002_cuddly_quasar.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "seeds" ADD COLUMN "cover_photo_url" text;

--- a/lib/db/migrations/meta/0002_snapshot.json
+++ b/lib/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,536 @@
+{
+  "id": "5efadb6e-d9e3-4a49-ab3c-f4ef8e744a39",
+  "prevId": "d5eb8d6b-135c-40a3-b1ff-4f882379fd57",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_emails": {
+      "name": "admin_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_emails_added_by_users_id_fk": {
+          "name": "admin_emails_added_by_users_id_fk",
+          "tableFrom": "admin_emails",
+          "tableTo": "users",
+          "columnsFrom": ["added_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_emails_email_unique": {
+          "name": "admin_emails_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seed_approvals": {
+      "name": "seed_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "seed_id": {
+          "name": "seed_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seed_approvals_seed_id_seeds_id_fk": {
+          "name": "seed_approvals_seed_id_seeds_id_fk",
+          "tableFrom": "seed_approvals",
+          "tableTo": "seeds",
+          "columnsFrom": ["seed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seed_approvals_approved_by_users_id_fk": {
+          "name": "seed_approvals_approved_by_users_id_fk",
+          "tableFrom": "seed_approvals",
+          "tableTo": "users",
+          "columnsFrom": ["approved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seed_comments": {
+      "name": "seed_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "seed_id": {
+          "name": "seed_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seed_comments_seed_id_seeds_id_fk": {
+          "name": "seed_comments_seed_id_seeds_id_fk",
+          "tableFrom": "seed_comments",
+          "tableTo": "seeds",
+          "columnsFrom": ["seed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seed_comments_user_id_users_id_fk": {
+          "name": "seed_comments_user_id_users_id_fk",
+          "tableFrom": "seed_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seed_supports": {
+      "name": "seed_supports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "seed_id": {
+          "name": "seed_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "seed_supports_unique": {
+          "name": "seed_supports_unique",
+          "columns": [
+            {
+              "expression": "seed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seed_supports_seed_id_seeds_id_fk": {
+          "name": "seed_supports_seed_id_seeds_id_fk",
+          "tableFrom": "seed_supports",
+          "tableTo": "seeds",
+          "columnsFrom": ["seed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seed_supports_user_id_users_id_fk": {
+          "name": "seed_supports_user_id_users_id_fk",
+          "tableFrom": "seed_supports",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seeds": {
+      "name": "seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gardeners": {
+          "name": "gardeners",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "location_address": {
+          "name": "location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_description": {
+          "name": "location_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lat": {
+          "name": "location_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lng": {
+          "name": "location_lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roots": {
+          "name": "roots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "support_people": {
+          "name": "support_people",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "water_have": {
+          "name": "water_have",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "water_need": {
+          "name": "water_need",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "budget": {
+          "name": "budget",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "obstacles": {
+          "name": "obstacles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cover_photo_url": {
+          "name": "cover_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seeds_created_by_users_id_fk": {
+          "name": "seeds_created_by_users_id_fk",
+          "tableFrom": "seeds",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.category": {
+      "name": "category",
+      "schema": "public",
+      "values": [
+        "daily_access",
+        "outdoor_play",
+        "balanced_growth",
+        "respect",
+        "connected_communities"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": ["user", "admin"]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": ["draft", "pending", "approved", "archived"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1774917593606,
       "tag": "0001_worthless_proemial_gods",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1775261339704,
+      "tag": "0002_cuddly_quasar",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -65,6 +65,7 @@ export const seeds = pgTable("seeds", {
   obstacles: text("obstacles"),
   imageUrl: text("image_url"),
   photos: jsonb("photos").$type<string[]>().notNull().default([]),
+  coverPhotoUrl: text("cover_photo_url"),
   status: statusEnum("status").notNull().default("pending"),
   createdBy: uuid("created_by")
     .notNull()

--- a/lib/validations/seed.ts
+++ b/lib/validations/seed.ts
@@ -1,42 +1,50 @@
 import { z } from "zod";
 
-export const seedFormSchema = z.object({
-  name: z
-    .string()
-    .min(1, "Project name is required")
-    .max(160, "Project name must be 160 characters or fewer"),
-  summary: z
-    .string()
-    .min(1, "Summary is required")
-    .max(10000, "Summary must be 10,000 characters or fewer"),
-  gardeners: z.array(z.string().max(200)).max(50).default([]),
-  locationAddress: z.string().optional(),
-  locationDescription: z.string().max(10000).optional(),
-  locationLat: z.number().optional(),
-  locationLng: z.number().optional(),
-  category: z.enum([
-    "daily_access",
-    "outdoor_play",
-    "balanced_growth",
-    "respect",
-    "connected_communities",
-  ]),
-  roots: z
-    .array(
-      z.object({
-        name: z.string().max(200),
-        committed: z.boolean(),
-      }),
-    )
-    .max(50)
-    .default([]),
-  supportPeople: z.array(z.string().max(200)).max(50).default([]),
-  waterHave: z.array(z.string().max(200)).max(50).default([]),
-  waterNeed: z.array(z.string().max(200)).max(50).default([]),
-  budget: z.string().max(500).optional(),
-  obstacles: z.string().max(10000).optional(),
-  photos: z.array(z.string().url()).max(5).default([]),
-  coverPhotoUrl: z.string().url().nullable().optional(),
-});
+export const seedFormSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, "Project name is required")
+      .max(160, "Project name must be 160 characters or fewer"),
+    summary: z
+      .string()
+      .min(1, "Summary is required")
+      .max(10000, "Summary must be 10,000 characters or fewer"),
+    gardeners: z.array(z.string().max(200)).max(50).default([]),
+    locationAddress: z.string().optional(),
+    locationDescription: z.string().max(10000).optional(),
+    locationLat: z.number().optional(),
+    locationLng: z.number().optional(),
+    category: z.enum([
+      "daily_access",
+      "outdoor_play",
+      "balanced_growth",
+      "respect",
+      "connected_communities",
+    ]),
+    roots: z
+      .array(
+        z.object({
+          name: z.string().max(200),
+          committed: z.boolean(),
+        }),
+      )
+      .max(50)
+      .default([]),
+    supportPeople: z.array(z.string().max(200)).max(50).default([]),
+    waterHave: z.array(z.string().max(200)).max(50).default([]),
+    waterNeed: z.array(z.string().max(200)).max(50).default([]),
+    budget: z.string().max(500).optional(),
+    obstacles: z.string().max(10000).optional(),
+    photos: z.array(z.string().url()).max(5).default([]),
+    coverPhotoUrl: z.string().url().nullable().optional(),
+  })
+  .refine(
+    (data) => !data.coverPhotoUrl || data.photos.includes(data.coverPhotoUrl),
+    {
+      message: "Cover photo must be one of the uploaded photos",
+      path: ["coverPhotoUrl"],
+    },
+  );
 
 export type SeedFormValues = z.infer<typeof seedFormSchema>;

--- a/lib/validations/seed.ts
+++ b/lib/validations/seed.ts
@@ -36,6 +36,7 @@ export const seedFormSchema = z.object({
   budget: z.string().max(500).optional(),
   obstacles: z.string().max(10000).optional(),
   photos: z.array(z.string().url()).max(5).default([]),
+  coverPhotoUrl: z.string().url().nullable().optional(),
 });
 
 export type SeedFormValues = z.infer<typeof seedFormSchema>;


### PR DESCRIPTION
## Summary
- Adds `coverPhotoUrl` field to the seeds table so creators can designate one of their uploaded photos as the primary cover image on the seed detail page
- Each photo thumbnail in the edit form gets a star button to set/unset as cover, with a visual badge on the active cover
- When a cover photo is set, the AI illustration moves to the photos grid; removing or deselecting the cover reverts to the AI image
- Seed cards on Explore pages continue to use the AI-generated illustration

Closes #15 #16

## Test plan
- [x] Edit a seed with uploaded photos — click the star on a photo to set it as cover
- [x] Verify the seed detail page shows the selected photo as the primary image
- [x] Verify the AI illustration appears in the photos grid below
- [x] Click the star again to unset — verify the AI illustration returns as primary
- [ ] Remove a photo that is set as cover — verify revert to AI illustration
- [ ] Confirm Explore page cards still show the AI illustration

🤖 Generated with [Claude Code](https://claude.com/claude-code)