### PR TITLE
Add Supporting tab to user dashboard

### DIFF
--- a/__tests__/components/dashboard/dashboard-content.test.tsx
+++ b/__tests__/components/dashboard/dashboard-content.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
+
+const mockUserSeeds = [
+  {
+    id: "seed-1",
+    name: "Community Garden",
+    category: "daily_access" as const,
+    status: "approved",
+    supportCount: 5,
+    createdAt: new Date("2024-06-01"),
+  },
+  {
+    id: "seed-2",
+    name: "Trail Cleanup",
+    category: "outdoor_play" as const,
+    status: "pending",
+    supportCount: 2,
+    createdAt: new Date("2024-07-01"),
+  },
+];
+
+const mockSupportedSeeds = [
+  {
+    id: "seed-3",
+    name: "River Restoration",
+    summary: "Restoring the riverbanks.",
+    category: "respect" as const,
+    imageUrl: "https://example.com/river.jpg",
+    supportCount: 12,
+  },
+  {
+    id: "seed-4",
+    name: "Bike Lane Project",
+    summary: "Adding bike lanes downtown.",
+    category: "connected_communities" as const,
+    imageUrl: null,
+    supportCount: 8,
+  },
+];
+
+describe("DashboardContent", () => {
+  it("shows Supporting tab by default", () => {
+    render(
+      <DashboardContent
+        userSeeds={mockUserSeeds}
+        supportedSeeds={mockSupportedSeeds}
+      />,
+    );
+
+    expect(screen.getByText("River Restoration")).toBeInTheDocument();
+    expect(screen.getByText("Bike Lane Project")).toBeInTheDocument();
+    expect(screen.queryByText("Community Garden")).not.toBeInTheDocument();
+  });
+
+  it("switches to My Seeds tab on click", async () => {
+    render(
+      <DashboardContent
+        userSeeds={mockUserSeeds}
+        supportedSeeds={mockSupportedSeeds}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /my seeds/i }));
+
+    expect(screen.getByText("Community Garden")).toBeInTheDocument();
+    expect(screen.getByText("Trail Cleanup")).toBeInTheDocument();
+    expect(screen.queryByText("River Restoration")).not.toBeInTheDocument();
+  });
+
+  it("switches back to Supporting tab", async () => {
+    render(
+      <DashboardContent
+        userSeeds={mockUserSeeds}
+        supportedSeeds={mockSupportedSeeds}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /my seeds/i }));
+    fireEvent.click(screen.getByRole("button", { name: /supporting/i }));
+
+    expect(screen.getByText("River Restoration")).toBeInTheDocument();
+    expect(screen.queryByText("Community Garden")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no supported seeds", () => {
+    render(<DashboardContent userSeeds={mockUserSeeds} supportedSeeds={[]} />);
+
+    expect(
+      screen.getByText("You haven't supported any seeds yet."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /explore seeds/i }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("shows empty state when no user seeds", async () => {
+    render(
+      <DashboardContent userSeeds={[]} supportedSeeds={mockSupportedSeeds} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /my seeds/i }));
+
+    expect(
+      screen.getByText("You haven't planted any seeds yet."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /plant your first seed/i }),
+    ).toHaveAttribute("href", "/seeds/new");
+  });
+
+  it("renders both tab buttons", () => {
+    render(
+      <DashboardContent
+        userSeeds={mockUserSeeds}
+        supportedSeeds={mockSupportedSeeds}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /supporting/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /my seeds/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Plus } from "lucide-react";
@@ -23,8 +24,7 @@ export default async function DashboardPage(props: {
   }
 
   const searchParams = await props.searchParams;
-  const activeTab =
-    searchParams.tab === "supporting" ? "supporting" : "my-seeds";
+  const activeTab = searchParams.tab === "my-seeds" ? "my-seeds" : "supporting";
 
   const [userSeeds, supportedSeeds] = await Promise.all([
     getSeedsByUser(session.user.id),
@@ -48,11 +48,13 @@ export default async function DashboardPage(props: {
         </Button>
       </div>
 
-      <DashboardContent
-        userSeeds={userSeeds}
-        supportedSeeds={supportedSeeds}
-        activeTab={activeTab}
-      />
+      <Suspense fallback={<div className="py-8 text-center">Loading...</div>}>
+        <DashboardContent
+          userSeeds={userSeeds}
+          supportedSeeds={supportedSeeds}
+          activeTab={activeTab}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,25 +4,38 @@ import { Plus } from "lucide-react";
 import type { Metadata } from "next";
 import { auth } from "@/auth";
 import { Button } from "@/components/ui/button";
-import { DashboardSeedList } from "@/components/dashboard/seed-list-table";
-import { getSeedsByUser } from "@/lib/db/queries/seeds";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
+import {
+  getSeedsByUser,
+  getSupportedSeedsByUser,
+} from "@/lib/db/queries/seeds";
 
 export const metadata: Metadata = {
-  title: "My Seeds | Seeds",
+  title: "Dashboard | Seeds",
 };
 
-export default async function DashboardPage() {
+export default async function DashboardPage(props: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
   const session = await auth();
   if (!session?.user?.id) {
     redirect("/api/auth/signin");
   }
-  const userSeeds = await getSeedsByUser(session.user.id);
+
+  const searchParams = await props.searchParams;
+  const activeTab =
+    searchParams.tab === "supporting" ? "supporting" : "my-seeds";
+
+  const [userSeeds, supportedSeeds] = await Promise.all([
+    getSeedsByUser(session.user.id),
+    getSupportedSeedsByUser(session.user.id),
+  ]);
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
       <div className="mb-8 flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">My Seeds</h1>
+          <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
           <p className="text-muted-foreground mt-1">
             Manage your community project proposals
           </p>
@@ -35,18 +48,11 @@ export default async function DashboardPage() {
         </Button>
       </div>
 
-      {userSeeds.length === 0 ? (
-        <div className="rounded-lg border border-dashed py-16 text-center">
-          <p className="text-muted-foreground mb-4 text-lg">
-            You haven&apos;t planted any seeds yet.
-          </p>
-          <Button asChild>
-            <Link href="/seeds/new">Plant Your First Seed</Link>
-          </Button>
-        </div>
-      ) : (
-        <DashboardSeedList seeds={userSeeds} />
-      )}
+      <DashboardContent
+        userSeeds={userSeeds}
+        supportedSeeds={supportedSeeds}
+        activeTab={activeTab}
+      />
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Plus } from "lucide-react";
@@ -15,16 +14,11 @@ export const metadata: Metadata = {
   title: "Dashboard | Seeds",
 };
 
-export default async function DashboardPage(props: {
-  searchParams: Promise<{ tab?: string }>;
-}) {
+export default async function DashboardPage() {
   const session = await auth();
   if (!session?.user?.id) {
     redirect("/api/auth/signin");
   }
-
-  const searchParams = await props.searchParams;
-  const activeTab = searchParams.tab === "my-seeds" ? "my-seeds" : "supporting";
 
   const [userSeeds, supportedSeeds] = await Promise.all([
     getSeedsByUser(session.user.id),
@@ -48,13 +42,7 @@ export default async function DashboardPage(props: {
         </Button>
       </div>
 
-      <Suspense fallback={<div className="py-8 text-center">Loading...</div>}>
-        <DashboardContent
-          userSeeds={userSeeds}
-          supportedSeeds={supportedSeeds}
-          activeTab={activeTab}
-        />
-      </Suspense>
+      <DashboardContent userSeeds={userSeeds} supportedSeeds={supportedSeeds} />
     </div>
   );
 }

--- a/app/seeds/[id]/page.tsx
+++ b/app/seeds/[id]/page.tsx
@@ -98,9 +98,25 @@ export async function generateMetadata(props: {
   const params = await props.params;
   const seed = await getSeedById(params.id);
   if (!seed) return { title: "Seed Not Found" };
+  const ogImage = seed.imageUrl;
   return {
     title: `${seed.name} | Seeds`,
     description: seed.summary.slice(0, 160),
+    openGraph: {
+      title: seed.name,
+      description: seed.summary.slice(0, 160),
+      ...(ogImage && {
+        images: [{ url: ogImage }],
+      }),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: seed.name,
+      description: seed.summary.slice(0, 160),
+      ...(ogImage && {
+        images: [ogImage],
+      }),
+    },
   };
 }
 

--- a/app/seeds/[id]/page.tsx
+++ b/app/seeds/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import { Mail, Pencil } from "lucide-react";
+import { Mail, Pencil, Sun } from "lucide-react";
 import { SeedIcon, type SeedIconName } from "@/components/icons/seed-icons";
 import { auth } from "@/auth";
 import { canEditSeed } from "@/lib/auth-utils";
@@ -370,12 +370,20 @@ export default async function SeedPage(props: {
             )}
           </div>
           {canEdit && (
-            <Button variant="outline" size="sm" className="mt-3" asChild>
-              <a href={`mailto:${supporters.map((s) => s.email).join(",")}`}>
-                <Mail className="mr-1.5 size-3.5" />
-                Email Supporters
-              </a>
-            </Button>
+            <div className="mt-3 flex gap-2">
+              <Button variant="outline" size="sm" asChild>
+                <Link href={`/dashboard/seeds/${seed.id}`}>
+                  <Sun className="mr-1.5 size-3.5" />
+                  View Supporters
+                </Link>
+              </Button>
+              <Button variant="outline" size="sm" asChild>
+                <a href={`mailto:${supporters.map((s) => s.email).join(",")}`}>
+                  <Mail className="mr-1.5 size-3.5" />
+                  Email Supporters
+                </a>
+              </Button>
+            </div>
           )}
         </div>
       )}

--- a/components/admin/seed-data-table.tsx
+++ b/components/admin/seed-data-table.tsx
@@ -131,12 +131,16 @@ export function AdminSeedTable({
                     <SeedStatusBadge status={seed.status} />
                   </TableCell>
                   <TableCell className="hidden sm:table-cell">
-                    <Link
-                      href={`/dashboard/seeds/${seed.id}`}
-                      className="hover:underline"
-                    >
-                      {seed.supportCount}
-                    </Link>
+                    {seed.supportCount > 0 ? (
+                      <Link
+                        href={`/dashboard/seeds/${seed.id}`}
+                        className="hover:underline"
+                      >
+                        {seed.supportCount}
+                      </Link>
+                    ) : (
+                      seed.supportCount
+                    )}
                   </TableCell>
                   <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
                     {new Date(seed.createdAt).toLocaleDateString("en-US")}

--- a/components/admin/seed-data-table.tsx
+++ b/components/admin/seed-data-table.tsx
@@ -131,7 +131,12 @@ export function AdminSeedTable({
                     <SeedStatusBadge status={seed.status} />
                   </TableCell>
                   <TableCell className="hidden sm:table-cell">
-                    {seed.supportCount}
+                    <Link
+                      href={`/dashboard/seeds/${seed.id}`}
+                      className="hover:underline"
+                    >
+                      {seed.supportCount}
+                    </Link>
                   </TableCell>
                   <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
                     {new Date(seed.createdAt).toLocaleDateString("en-US")}

--- a/components/dashboard/dashboard-content.tsx
+++ b/components/dashboard/dashboard-content.tsx
@@ -31,7 +31,7 @@ interface SupportedSeed {
 export function DashboardContent({
   userSeeds,
   supportedSeeds,
-  activeTab = "my-seeds",
+  activeTab = "supporting",
 }: {
   userSeeds: DashboardSeed[];
   supportedSeeds: SupportedSeed[];
@@ -42,7 +42,7 @@ export function DashboardContent({
 
   function setTab(tab: DashboardTab) {
     const params = new URLSearchParams(searchParams.toString());
-    if (tab === "my-seeds") {
+    if (tab === "supporting") {
       params.delete("tab");
     } else {
       params.set("tab", tab);
@@ -52,16 +52,7 @@ export function DashboardContent({
 
   return (
     <>
-      <div className="mb-6 flex gap-1 rounded-lg border p-1 self-start w-fit">
-        <Button
-          variant={activeTab === "my-seeds" ? "secondary" : "ghost"}
-          size="sm"
-          onClick={() => setTab("my-seeds")}
-          className="gap-1.5"
-        >
-          <Sprout className="size-4" />
-          My Seeds
-        </Button>
+      <div className="mb-6 flex w-fit gap-1 self-start rounded-lg border p-1">
         <Button
           variant={activeTab === "supporting" ? "secondary" : "ghost"}
           size="sm"
@@ -71,35 +62,44 @@ export function DashboardContent({
           <Sun className="size-4" />
           Supporting
         </Button>
+        <Button
+          variant={activeTab === "my-seeds" ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => setTab("my-seeds")}
+          className="gap-1.5"
+        >
+          <Sprout className="size-4" />
+          My Seeds
+        </Button>
       </div>
 
-      {activeTab === "my-seeds" ? (
-        userSeeds.length === 0 ? (
+      {activeTab === "supporting" ? (
+        supportedSeeds.length === 0 ? (
           <div className="rounded-lg border border-dashed py-16 text-center">
             <p className="text-muted-foreground mb-4 text-lg">
-              You haven&apos;t planted any seeds yet.
+              You haven&apos;t supported any seeds yet.
+            </p>
+            <p className="text-muted-foreground mb-4 text-sm">
+              Explore seeds and tap support this seed to show your support.
             </p>
             <Button asChild>
-              <Link href="/seeds/new">Plant Your First Seed</Link>
+              <Link href="/">Explore Seeds</Link>
             </Button>
           </div>
         ) : (
-          <DashboardSeedList seeds={userSeeds} />
+          <SeedListView seeds={supportedSeeds} />
         )
-      ) : supportedSeeds.length === 0 ? (
+      ) : userSeeds.length === 0 ? (
         <div className="rounded-lg border border-dashed py-16 text-center">
           <p className="text-muted-foreground mb-4 text-lg">
-            You haven&apos;t supported any seeds yet.
-          </p>
-          <p className="text-muted-foreground mb-4 text-sm">
-            Explore seeds and tap support this seed to show your support.
+            You haven&apos;t planted any seeds yet.
           </p>
           <Button asChild>
-            <Link href="/">Explore Seeds</Link>
+            <Link href="/seeds/new">Plant Your First Seed</Link>
           </Button>
         </div>
       ) : (
-        <SeedListView seeds={supportedSeeds} />
+        <DashboardSeedList seeds={userSeeds} />
       )}
     </>
   );

--- a/components/dashboard/dashboard-content.tsx
+++ b/components/dashboard/dashboard-content.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Sprout, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DashboardSeedList } from "@/components/dashboard/seed-list-table";
+import { SeedListView } from "@/components/seeds/seed-list-view";
+import type { CategoryKey } from "@/lib/categories";
+
+type DashboardTab = "my-seeds" | "supporting";
+
+interface DashboardSeed {
+  id: string;
+  name: string;
+  category: CategoryKey;
+  status: string;
+  supportCount: number;
+  createdAt: Date;
+}
+
+interface SupportedSeed {
+  id: string;
+  name: string;
+  summary: string;
+  category: CategoryKey;
+  imageUrl: string | null;
+  supportCount: number;
+}
+
+export function DashboardContent({
+  userSeeds,
+  supportedSeeds,
+  activeTab = "my-seeds",
+}: {
+  userSeeds: DashboardSeed[];
+  supportedSeeds: SupportedSeed[];
+  activeTab?: DashboardTab;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  function setTab(tab: DashboardTab) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (tab === "my-seeds") {
+      params.delete("tab");
+    } else {
+      params.set("tab", tab);
+    }
+    router.push(`?${params.toString()}`);
+  }
+
+  return (
+    <>
+      <div className="mb-6 flex gap-1 rounded-lg border p-1 self-start w-fit">
+        <Button
+          variant={activeTab === "my-seeds" ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => setTab("my-seeds")}
+          className="gap-1.5"
+        >
+          <Sprout className="size-4" />
+          My Seeds
+        </Button>
+        <Button
+          variant={activeTab === "supporting" ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => setTab("supporting")}
+          className="gap-1.5"
+        >
+          <Sun className="size-4" />
+          Supporting
+        </Button>
+      </div>
+
+      {activeTab === "my-seeds" ? (
+        userSeeds.length === 0 ? (
+          <div className="rounded-lg border border-dashed py-16 text-center">
+            <p className="text-muted-foreground mb-4 text-lg">
+              You haven&apos;t planted any seeds yet.
+            </p>
+            <Button asChild>
+              <Link href="/seeds/new">Plant Your First Seed</Link>
+            </Button>
+          </div>
+        ) : (
+          <DashboardSeedList seeds={userSeeds} />
+        )
+      ) : supportedSeeds.length === 0 ? (
+        <div className="rounded-lg border border-dashed py-16 text-center">
+          <p className="text-muted-foreground mb-4 text-lg">
+            You haven&apos;t supported any seeds yet.
+          </p>
+          <p className="text-muted-foreground mb-4 text-sm">
+            Explore seeds and tap support this seed to show your support.
+          </p>
+          <Button asChild>
+            <Link href="/">Explore Seeds</Link>
+          </Button>
+        </div>
+      ) : (
+        <SeedListView seeds={supportedSeeds} />
+      )}
+    </>
+  );
+}

--- a/components/dashboard/dashboard-content.tsx
+++ b/components/dashboard/dashboard-content.tsx
@@ -1,14 +1,14 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
 import { Sprout, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DashboardSeedList } from "@/components/dashboard/seed-list-table";
 import { SeedListView } from "@/components/seeds/seed-list-view";
 import type { CategoryKey } from "@/lib/categories";
 
-type DashboardTab = "my-seeds" | "supporting";
+type DashboardTab = "supporting" | "my-seeds";
 
 interface DashboardSeed {
   id: string;
@@ -31,24 +31,11 @@ interface SupportedSeed {
 export function DashboardContent({
   userSeeds,
   supportedSeeds,
-  activeTab = "supporting",
 }: {
   userSeeds: DashboardSeed[];
   supportedSeeds: SupportedSeed[];
-  activeTab?: DashboardTab;
 }) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  function setTab(tab: DashboardTab) {
-    const params = new URLSearchParams(searchParams.toString());
-    if (tab === "supporting") {
-      params.delete("tab");
-    } else {
-      params.set("tab", tab);
-    }
-    router.push(`?${params.toString()}`);
-  }
+  const [activeTab, setActiveTab] = useState<DashboardTab>("supporting");
 
   return (
     <>
@@ -56,7 +43,7 @@ export function DashboardContent({
         <Button
           variant={activeTab === "supporting" ? "secondary" : "ghost"}
           size="sm"
-          onClick={() => setTab("supporting")}
+          onClick={() => setActiveTab("supporting")}
           className="gap-1.5"
         >
           <Sun className="size-4" />
@@ -65,7 +52,7 @@ export function DashboardContent({
         <Button
           variant={activeTab === "my-seeds" ? "secondary" : "ghost"}
           size="sm"
-          onClick={() => setTab("my-seeds")}
+          onClick={() => setActiveTab("my-seeds")}
           className="gap-1.5"
         >
           <Sprout className="size-4" />

--- a/lib/db/queries/seeds.ts
+++ b/lib/db/queries/seeds.ts
@@ -160,7 +160,7 @@ export async function getSeedsByUser(userId: string) {
       )`.as("support_count"),
     })
     .from(seeds)
-    .where(and(eq(seeds.createdBy, userId), sql`${seeds.status} != 'archived'`))
+    .where(eq(seeds.createdBy, userId))
     .orderBy(desc(seeds.createdAt));
 }
 
@@ -176,7 +176,7 @@ export async function getSupportedSeedsByUser(userId: string) {
     })
     .from(seeds)
     .innerJoin(seedSupports, eq(seeds.id, seedSupports.seedId))
-    .where(and(eq(seedSupports.userId, userId), eq(seeds.status, "approved")))
+    .where(eq(seedSupports.userId, userId))
     .orderBy(desc(seedSupports.createdAt));
 }
 

--- a/lib/db/queries/seeds.ts
+++ b/lib/db/queries/seeds.ts
@@ -164,6 +164,22 @@ export async function getSeedsByUser(userId: string) {
     .orderBy(desc(seeds.createdAt));
 }
 
+export async function getSupportedSeedsByUser(userId: string) {
+  return db
+    .select({
+      id: seeds.id,
+      name: seeds.name,
+      summary: seeds.summary,
+      category: seeds.category,
+      imageUrl: seeds.imageUrl,
+      supportCount: supportCountSql,
+    })
+    .from(seeds)
+    .innerJoin(seedSupports, eq(seeds.id, seedSupports.seedId))
+    .where(and(eq(seedSupports.userId, userId), eq(seeds.status, "approved")))
+    .orderBy(desc(seedSupports.createdAt));
+}
+
 export async function getSeedSupportCount(seedId: string) {
   const result = await db
     .select({ count: count() })


### PR DESCRIPTION
## Summary
- Adds tabbed dashboard (Supporting | My Seeds) with Supporting as default
- "Supporting" tab shows seeds the user has supported as a card grid (reuses `SeedCard`), sorted by most recently supported
- "My Seeds" tab retains the existing seed management table, now includes archived seeds
- Removed status filters from dashboard queries so users see all their seeds regardless of status
- Added OG and Twitter Card tags to seed detail pages for social sharing
- Added "View Supporters" link on seed detail page and clickable support count in admin table

## Test plan
- [x] Visit /dashboard — see "Supporting" tab active by default
- [x] Click "My Seeds" tab — see seed management table including archived seeds
- [ ] Test empty states for both tabs
- [x] On a seed detail page (as owner), verify "View Supporters" button appears
- [x] In admin dashboard, click a non-zero support count — goes to supporters page
- [ ] Share a seed URL — verify OG image and title render in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)