### PR TITLE
Use cover photo as OG image for seed detail pages

### DIFF
--- a/app/seeds/[id]/page.tsx
+++ b/app/seeds/[id]/page.tsx
@@ -98,7 +98,7 @@ export async function generateMetadata(props: {
   const params = await props.params;
   const seed = await getSeedById(params.id);
   if (!seed) return { title: "Seed Not Found" };
-  const ogImage = seed.imageUrl;
+  const ogImage = seed.coverPhotoUrl ?? seed.imageUrl;
   return {
     title: `${seed.name} | Seeds`,
     description: seed.summary.slice(0, 160),


### PR DESCRIPTION
## Summary
- OG image now prefers `coverPhotoUrl` over `imageUrl` (AI illustration)
- Falls back to AI illustration when no cover photo is set

One-line change in `generateMetadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)