### PR TITLE
Admin-editable site banner + NPC Festival cancellation

### DIFF
--- a/__tests__/lib/actions/admin.test.ts
+++ b/__tests__/lib/actions/admin.test.ts
@@ -23,6 +23,7 @@ import { db } from "@/lib/db";
 import {
   approveSeed,
   archiveSeed,
+  setBannerConfig,
   unapproveSeed,
   unarchiveSeed,
 } from "@/lib/actions/admin";
@@ -246,5 +247,110 @@ describe("unapproveSeed", () => {
     expect(revalidatePath).toHaveBeenCalledWith("/admin");
     expect(revalidatePath).toHaveBeenCalledWith("/");
     expect(revalidatePath).toHaveBeenCalledWith("/seeds/seed-1");
+  });
+});
+
+describe("setBannerConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects unauthenticated users", async () => {
+    setAuthMock(auth, null);
+
+    await expect(
+      setBannerConfig({ enabled: true, message: "Hi", href: "" }),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects non-admin users", async () => {
+    setAuthMock(auth, mockSession({ role: "user" }));
+
+    await expect(
+      setBannerConfig({ enabled: true, message: "Hi", href: "" }),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("accepts a valid config", async () => {
+    setAuthMock(auth, mockAdminSession());
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+      }),
+    } as any);
+
+    const result = await setBannerConfig({
+      enabled: true,
+      message: "Join us tonight",
+      href: "https://example.com",
+    });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it("rejects non-https hrefs", async () => {
+    setAuthMock(auth, mockAdminSession());
+
+    const result = await setBannerConfig({
+      enabled: true,
+      message: "Hi",
+      href: "javascript:alert(1)",
+    });
+
+    expect(result).toEqual({ success: false, error: expect.any(String) });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects http:// hrefs", async () => {
+    setAuthMock(auth, mockAdminSession());
+
+    const result = await setBannerConfig({
+      enabled: true,
+      message: "Hi",
+      href: "http://example.com",
+    });
+
+    expect(result).toEqual({ success: false, error: expect.any(String) });
+  });
+
+  it("rejects malformed URLs", async () => {
+    setAuthMock(auth, mockAdminSession());
+
+    const result = await setBannerConfig({
+      enabled: true,
+      message: "Hi",
+      href: "https://",
+    });
+
+    expect(result).toEqual({ success: false, error: expect.any(String) });
+  });
+
+  it("rejects over-length messages", async () => {
+    setAuthMock(auth, mockAdminSession());
+
+    const result = await setBannerConfig({
+      enabled: true,
+      message: "x".repeat(201),
+      href: "",
+    });
+
+    expect(result).toEqual({ success: false, error: expect.any(String) });
+  });
+
+  it("accepts an empty href", async () => {
+    setAuthMock(auth, mockAdminSession());
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+      }),
+    } as any);
+
+    const result = await setBannerConfig({
+      enabled: false,
+      message: "",
+      href: "",
+    });
+
+    expect(result).toEqual({ success: true });
   });
 });

--- a/__tests__/lib/actions/admin.test.ts
+++ b/__tests__/lib/actions/admin.test.ts
@@ -346,4 +346,29 @@ describe("setBannerConfig", () => {
 
     expect(result).toEqual({ success: true });
   });
+
+  it("rejects enabled=true with an empty message", async () => {
+    setAuthMock(auth, mockAdminSession());
+
+    const result = await setBannerConfig({
+      enabled: true,
+      message: "",
+      href: "",
+    });
+
+    expect(result).toEqual({ success: false, error: expect.any(String) });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects enabled=true with a whitespace-only message", async () => {
+    setAuthMock(auth, mockAdminSession());
+
+    const result = await setBannerConfig({
+      enabled: true,
+      message: "   ",
+      href: "",
+    });
+
+    expect(result).toEqual({ success: false, error: expect.any(String) });
+  });
 });

--- a/__tests__/lib/actions/admin.test.ts
+++ b/__tests__/lib/actions/admin.test.ts
@@ -5,6 +5,7 @@ import {
   mockAdminSession,
   mockDbUpdateChain,
   mockDbInsertSimpleChain,
+  mockDbInsertOnConflictChain,
   setAuthMock,
 } from "../../test-utils";
 
@@ -273,11 +274,7 @@ describe("setBannerConfig", () => {
 
   it("accepts a valid config", async () => {
     setAuthMock(auth, mockAdminSession());
-    vi.mocked(db.insert).mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-      }),
-    } as any);
+    vi.mocked(db.insert).mockReturnValue(mockDbInsertOnConflictChain() as any);
 
     const result = await setBannerConfig({
       enabled: true,
@@ -339,11 +336,7 @@ describe("setBannerConfig", () => {
 
   it("accepts an empty href", async () => {
     setAuthMock(auth, mockAdminSession());
-    vi.mocked(db.insert).mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-      }),
-    } as any);
+    vi.mocked(db.insert).mockReturnValue(mockDbInsertOnConflictChain() as any);
 
     const result = await setBannerConfig({
       enabled: false,

--- a/__tests__/test-utils.ts
+++ b/__tests__/test-utils.ts
@@ -124,3 +124,14 @@ export function mockDbDeleteChain() {
   const mockWhere = vi.fn().mockResolvedValue(undefined);
   return { where: mockWhere };
 }
+
+/**
+ * Mock a db.insert(table).values({}).onConflictDoUpdate({}) chain.
+ */
+export function mockDbInsertOnConflictChain() {
+  const mockOnConflict = vi.fn().mockResolvedValue(undefined);
+  const mockValues = vi
+    .fn()
+    .mockReturnValue({ onConflictDoUpdate: mockOnConflict });
+  return { values: mockValues, _onConflictDoUpdate: mockOnConflict };
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -271,48 +271,30 @@ export default function AboutPage() {
                     <div className="my-1 w-px flex-1 bg-border" />
                   )}
                 </div>
-                <div className={cn("pb-4", step.cancelled && "opacity-60")}>
-                  <p
-                    className={cn(
-                      "font-semibold",
-                      step.cancelled && "line-through",
-                    )}
-                  >
-                    {step.phase}
-                  </p>
+                <div className="pb-4">
                   {step.cancelled && (
                     <p className="text-sm font-semibold text-destructive">
                       {step.cancelled}
                     </p>
                   )}
-                  <p
-                    className={cn(
-                      "text-muted-foreground text-sm",
-                      step.cancelled && "line-through",
-                    )}
+                  <div
+                    className={cn(step.cancelled && "line-through opacity-60")}
                   >
-                    <Calendar className="mr-1 inline size-3.5 align-text-bottom" />
-                    {step.when}
-                  </p>
-                  {"location" in step && step.location && (
-                    <p
-                      className={cn(
-                        "text-muted-foreground text-sm",
-                        step.cancelled && "line-through",
-                      )}
-                    >
-                      <MapPin className="mr-1 inline size-3.5 align-text-bottom" />
-                      {step.location}
+                    <p className="font-semibold">{step.phase}</p>
+                    <p className="text-muted-foreground text-sm">
+                      <Calendar className="mr-1 inline size-3.5 align-text-bottom" />
+                      {step.when}
                     </p>
-                  )}
-                  <p
-                    className={cn(
-                      "text-muted-foreground mt-1 text-sm",
-                      step.cancelled && "line-through",
+                    {step.location && (
+                      <p className="text-muted-foreground text-sm">
+                        <MapPin className="mr-1 inline size-3.5 align-text-bottom" />
+                        {step.location}
+                      </p>
                     )}
-                  >
-                    {step.detail}
-                  </p>
+                    <p className="text-muted-foreground mt-1 text-sm">
+                      {step.detail}
+                    </p>
+                  </div>
                 </div>
               </div>
             ))}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -60,7 +60,13 @@ const seedTraits: {
   },
 ];
 
-const timeline = [
+const timeline: {
+  phase: string;
+  when: string;
+  location?: string;
+  detail: string;
+  cancelled?: string;
+}[] = [
   {
     phase: "Seed Drive Kickoff",
     when: "March 5",
@@ -92,6 +98,7 @@ const timeline = [
     when: "April 25",
     location: "Greenway Farm, 4960 Gann Store Rd.",
     detail: "Gear sale, seed pitch, music + more",
+    cancelled: "Cancelled due to weather",
   },
   {
     phase: "Harvest",
@@ -264,19 +271,46 @@ export default function AboutPage() {
                     <div className="my-1 w-px flex-1 bg-border" />
                   )}
                 </div>
-                <div className="pb-4">
-                  <p className="font-semibold">{step.phase}</p>
-                  <p className="text-muted-foreground text-sm">
+                <div className={cn("pb-4", step.cancelled && "opacity-60")}>
+                  <p
+                    className={cn(
+                      "font-semibold",
+                      step.cancelled && "line-through",
+                    )}
+                  >
+                    {step.phase}
+                  </p>
+                  {step.cancelled && (
+                    <p className="text-sm font-semibold text-destructive">
+                      {step.cancelled}
+                    </p>
+                  )}
+                  <p
+                    className={cn(
+                      "text-muted-foreground text-sm",
+                      step.cancelled && "line-through",
+                    )}
+                  >
                     <Calendar className="mr-1 inline size-3.5 align-text-bottom" />
                     {step.when}
                   </p>
                   {"location" in step && step.location && (
-                    <p className="text-muted-foreground text-sm">
+                    <p
+                      className={cn(
+                        "text-muted-foreground text-sm",
+                        step.cancelled && "line-through",
+                      )}
+                    >
                       <MapPin className="mr-1 inline size-3.5 align-text-bottom" />
                       {step.location}
                     </p>
                   )}
-                  <p className="text-muted-foreground mt-1 text-sm">
+                  <p
+                    className={cn(
+                      "text-muted-foreground mt-1 text-sm",
+                      step.cancelled && "line-through",
+                    )}
+                  >
                     {step.detail}
                   </p>
                 </div>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { AdminCommentsTable } from "@/components/admin/admin-comments-table";
 import { AdminEmailList } from "@/components/admin/admin-email-list";
+import { BannerSettings } from "@/components/admin/banner-settings";
 import { ExportButtons } from "@/components/admin/export-buttons";
 import { HomepagePhaseToggle } from "@/components/admin/homepage-phase-toggle";
 import { AdminSeedTable } from "@/components/admin/seed-data-table";
@@ -13,7 +14,7 @@ import {
   getAllSeeds,
   getSupporterEmailsMap,
 } from "@/lib/db/queries/admin";
-import { getHomepagePhase } from "@/lib/db/queries/settings";
+import { getBannerConfig, getHomepagePhase } from "@/lib/db/queries/settings";
 
 export const metadata: Metadata = {
   title: "Admin | Seeds",
@@ -36,12 +37,14 @@ export default async function AdminPage() {
     adminEmails,
     allComments,
     homepagePhase,
+    bannerConfig,
   ] = await Promise.all([
     getAllSeeds(),
     getSupporterEmailsMap(),
     getAdminEmails(),
     getAllComments(),
     getHomepagePhase(),
+    getBannerConfig(),
   ]);
 
   return (
@@ -94,6 +97,16 @@ export default async function AdminPage() {
 
         <TabsContent value="settings">
           <div className="mt-4 space-y-8">
+            <div className="space-y-4">
+              <div>
+                <h2 className="text-lg font-semibold">Site Banner</h2>
+                <p className="text-muted-foreground text-sm">
+                  Shown at the top of every page. Use it to promote an event or
+                  announcement, then disable when it&apos;s over.
+                </p>
+              </div>
+              <BannerSettings initial={bannerConfig} />
+            </div>
             <div className="space-y-4">
               <div>
                 <h2 className="text-lg font-semibold">Homepage Phase</h2>

--- a/components/admin/banner-settings.tsx
+++ b/components/admin/banner-settings.tsx
@@ -85,7 +85,16 @@ export function BannerSettings({ initial }: { initial: BannerConfig }) {
         </p>
       </div>
 
-      <Button onClick={save} disabled={!dirty || isPending}>
+      {enabled && !message.trim() && (
+        <p className="text-destructive text-sm">
+          Add a message or disable the banner before saving.
+        </p>
+      )}
+
+      <Button
+        onClick={save}
+        disabled={!dirty || isPending || (enabled && !message.trim())}
+      >
         {isPending ? "Saving..." : "Save"}
       </Button>
     </div>

--- a/components/admin/banner-settings.tsx
+++ b/components/admin/banner-settings.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { setBannerConfig } from "@/lib/actions/admin";
+import type { BannerConfig } from "@/lib/db/queries/settings";
+
+export function BannerSettings({ initial }: { initial: BannerConfig }) {
+  const [enabled, setEnabled] = useState(initial.enabled);
+  const [message, setMessage] = useState(initial.message);
+  const [href, setHref] = useState(initial.href);
+  const [isPending, startTransition] = useTransition();
+
+  const dirty =
+    enabled !== initial.enabled ||
+    message !== initial.message ||
+    href !== initial.href;
+
+  function save() {
+    startTransition(async () => {
+      const result = await setBannerConfig({ enabled, message, href });
+      if (result.success) toast.success("Banner updated");
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant={enabled ? "default" : "outline"}
+          size="sm"
+          onClick={() => setEnabled(true)}
+        >
+          Enabled
+        </Button>
+        <Button
+          type="button"
+          variant={!enabled ? "default" : "outline"}
+          size="sm"
+          onClick={() => setEnabled(false)}
+        >
+          Disabled
+        </Button>
+        <span className="text-muted-foreground text-sm">
+          {enabled ? "Banner is live" : "Banner is hidden"}
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="banner-message">Message</Label>
+        <Textarea
+          id="banner-message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="TONIGHT: Join us for the Seed Pitch Night"
+          rows={2}
+          maxLength={200}
+        />
+        <p className="text-muted-foreground text-xs">
+          Shown across the top of the site. Keep it short (up to 200 chars).
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="banner-href">Link URL (optional)</Label>
+        <Input
+          id="banner-href"
+          type="url"
+          value={href}
+          onChange={(e) => setHref(e.target.value)}
+          placeholder="https://example.com/event"
+        />
+        <p className="text-muted-foreground text-xs">
+          If set, the banner becomes a link opening in a new tab.
+        </p>
+      </div>
+
+      <Button onClick={save} disabled={!dirty || isPending}>
+        {isPending ? "Saving..." : "Save"}
+      </Button>
+    </div>
+  );
+}

--- a/components/admin/banner-settings.tsx
+++ b/components/admin/banner-settings.tsx
@@ -23,7 +23,11 @@ export function BannerSettings({ initial }: { initial: BannerConfig }) {
   function save() {
     startTransition(async () => {
       const result = await setBannerConfig({ enabled, message, href });
-      if (result.success) toast.success("Banner updated");
+      if (result.success) {
+        toast.success("Banner updated");
+      } else {
+        toast.error(result.error);
+      }
     });
   }
 
@@ -70,7 +74,8 @@ export function BannerSettings({ initial }: { initial: BannerConfig }) {
         <Label htmlFor="banner-href">Link URL (optional)</Label>
         <Input
           id="banner-href"
-          type="url"
+          type="text"
+          inputMode="url"
           value={href}
           onChange={(e) => setHref(e.target.value)}
           placeholder="https://example.com/event"

--- a/components/layout/event-banner.tsx
+++ b/components/layout/event-banner.tsx
@@ -1,20 +1,30 @@
 import { ExternalLink } from "lucide-react";
+import { getBannerConfig } from "@/lib/db/queries/settings";
 
-export function EventBanner() {
-  return (
-    <a
-      href="https://www.studioourscha.com/event-details/national-park-city-seed-pitch-night"
-      target="_blank"
-      rel="noopener noreferrer"
-      className="block bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-    >
-      <div className="mx-auto flex max-w-6xl items-center justify-center gap-2 px-4 py-2 text-center text-sm font-medium">
-        <span>
-          <span className="font-semibold">TONIGHT:</span> Join us for the
-          National Park City Seed Pitch Night
-        </span>
-        <ExternalLink className="h-3.5 w-3.5 shrink-0" />
-      </div>
-    </a>
+export async function EventBanner() {
+  const config = await getBannerConfig();
+
+  if (!config.enabled || !config.message) return null;
+
+  const content = (
+    <div className="mx-auto flex max-w-6xl items-center justify-center gap-2 px-4 py-2 text-center text-sm font-medium">
+      <span>{config.message}</span>
+      {config.href && <ExternalLink className="h-3.5 w-3.5 shrink-0" />}
+    </div>
   );
+
+  if (config.href) {
+    return (
+      <a
+        href={config.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return <div className="bg-primary text-primary-foreground">{content}</div>;
 }

--- a/lib/actions/admin.ts
+++ b/lib/actions/admin.ts
@@ -133,6 +133,48 @@ export async function setSeedBadges(seedId: string, badges: BadgeKey[]) {
   return { success: true };
 }
 
+export async function setBannerConfig(input: {
+  enabled: boolean;
+  message: string;
+  href: string;
+}) {
+  await requireAdmin();
+
+  const entries = [
+    { key: "banner_enabled", value: input.enabled ? "true" : "false" },
+    { key: "banner_message", value: input.message.trim() },
+    { key: "banner_href", value: input.href.trim() },
+  ];
+
+  await db.batch([
+    db
+      .insert(siteSettings)
+      .values({ ...entries[0], updatedAt: new Date() })
+      .onConflictDoUpdate({
+        target: siteSettings.key,
+        set: { value: entries[0].value, updatedAt: new Date() },
+      }),
+    db
+      .insert(siteSettings)
+      .values({ ...entries[1], updatedAt: new Date() })
+      .onConflictDoUpdate({
+        target: siteSettings.key,
+        set: { value: entries[1].value, updatedAt: new Date() },
+      }),
+    db
+      .insert(siteSettings)
+      .values({ ...entries[2], updatedAt: new Date() })
+      .onConflictDoUpdate({
+        target: siteSettings.key,
+        set: { value: entries[2].value, updatedAt: new Date() },
+      }),
+  ]);
+
+  // Banner renders site-wide, so bust every cached route.
+  revalidatePath("/", "layout");
+  return { success: true };
+}
+
 export async function setHomepagePhase(phase: 1 | 2) {
   await requireAdmin();
 

--- a/lib/actions/admin.ts
+++ b/lib/actions/admin.ts
@@ -1,11 +1,34 @@
 "use server";
 
-import { eq } from "drizzle-orm";
-import { revalidatePath } from "next/cache";
+import { eq, sql } from "drizzle-orm";
+import { revalidatePath, updateTag } from "next/cache";
+import { z } from "zod";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { seedApprovals, seeds, siteSettings } from "@/lib/db/schema";
 import { badgeKeys, type BadgeKey } from "@/lib/badges";
+import { BANNER_CACHE_TAG } from "@/lib/db/queries/settings";
+
+const bannerConfigSchema = z.object({
+  enabled: z.boolean(),
+  message: z.string().max(200, "Message must be 200 characters or fewer"),
+  href: z
+    .string()
+    .max(2000)
+    .refine(
+      (v) => v === "" || /^https:\/\//i.test(v),
+      "Link must start with https://",
+    )
+    .refine((v) => {
+      if (v === "") return true;
+      try {
+        new URL(v);
+        return true;
+      } catch {
+        return false;
+      }
+    }, "Invalid URL"),
+});
 
 const STATUS_LISTING_PATHS = [
   "/status/seeds",
@@ -140,39 +163,44 @@ export async function setBannerConfig(input: {
 }) {
   await requireAdmin();
 
-  const entries = [
-    { key: "banner_enabled", value: input.enabled ? "true" : "false" },
-    { key: "banner_message", value: input.message.trim() },
-    { key: "banner_href", value: input.href.trim() },
-  ];
+  const parsed = bannerConfigSchema.safeParse({
+    enabled: input.enabled,
+    message: input.message.trim(),
+    href: input.href.trim(),
+  });
+  if (!parsed.success) {
+    return {
+      success: false as const,
+      error: parsed.error.issues[0]?.message ?? "Invalid banner config",
+    };
+  }
 
-  await db.batch([
-    db
-      .insert(siteSettings)
-      .values({ ...entries[0], updatedAt: new Date() })
-      .onConflictDoUpdate({
-        target: siteSettings.key,
-        set: { value: entries[0].value, updatedAt: new Date() },
-      }),
-    db
-      .insert(siteSettings)
-      .values({ ...entries[1], updatedAt: new Date() })
-      .onConflictDoUpdate({
-        target: siteSettings.key,
-        set: { value: entries[1].value, updatedAt: new Date() },
-      }),
-    db
-      .insert(siteSettings)
-      .values({ ...entries[2], updatedAt: new Date() })
-      .onConflictDoUpdate({
-        target: siteSettings.key,
-        set: { value: entries[2].value, updatedAt: new Date() },
-      }),
-  ]);
+  const { enabled, message, href } = parsed.data;
+  const now = new Date();
 
-  // Banner renders site-wide, so bust every cached route.
-  revalidatePath("/", "layout");
-  return { success: true };
+  // Single multi-row upsert — all three keys land together or not at all,
+  // avoiding a partial state like "enabled flipped but message unchanged".
+  await db
+    .insert(siteSettings)
+    .values([
+      {
+        key: "banner_enabled",
+        value: enabled ? "true" : "false",
+        updatedAt: now,
+      },
+      { key: "banner_message", value: message, updatedAt: now },
+      { key: "banner_href", value: href, updatedAt: now },
+    ])
+    .onConflictDoUpdate({
+      target: siteSettings.key,
+      set: {
+        value: sql`excluded.value`,
+        updatedAt: sql`excluded.updated_at`,
+      },
+    });
+
+  updateTag(BANNER_CACHE_TAG);
+  return { success: true as const };
 }
 
 export async function setHomepagePhase(phase: 1 | 2) {

--- a/lib/actions/admin.ts
+++ b/lib/actions/admin.ts
@@ -12,26 +12,31 @@ import {
   BANNER_SETTING_KEYS,
 } from "@/lib/db/queries/settings";
 
-const bannerConfigSchema = z.object({
-  enabled: z.boolean(),
-  message: z.string().max(200, "Message must be 200 characters or fewer"),
-  href: z
-    .string()
-    .max(2000)
-    .refine(
-      (v) => v === "" || /^https:\/\//i.test(v),
-      "Link must start with https://",
-    )
-    .refine((v) => {
-      if (v === "") return true;
-      try {
-        new URL(v);
-        return true;
-      } catch {
-        return false;
-      }
-    }, "Invalid URL"),
-});
+const bannerConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    message: z.string().max(200, "Message must be 200 characters or fewer"),
+    href: z
+      .string()
+      .max(2000)
+      .refine(
+        (v) => v === "" || /^https:\/\//i.test(v),
+        "Link must start with https://",
+      )
+      .refine((v) => {
+        if (v === "") return true;
+        try {
+          new URL(v);
+          return true;
+        } catch {
+          return false;
+        }
+      }, "Invalid URL"),
+  })
+  .refine((data) => !data.enabled || data.message.length > 0, {
+    message: "Enabled banner must have a message",
+    path: ["message"],
+  });
 
 const STATUS_LISTING_PATHS = [
   "/status/seeds",

--- a/lib/actions/admin.ts
+++ b/lib/actions/admin.ts
@@ -7,7 +7,10 @@ import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { seedApprovals, seeds, siteSettings } from "@/lib/db/schema";
 import { badgeKeys, type BadgeKey } from "@/lib/badges";
-import { BANNER_CACHE_TAG } from "@/lib/db/queries/settings";
+import {
+  BANNER_CACHE_TAG,
+  BANNER_SETTING_KEYS,
+} from "@/lib/db/queries/settings";
 
 const bannerConfigSchema = z.object({
   enabled: z.boolean(),
@@ -184,12 +187,12 @@ export async function setBannerConfig(input: {
     .insert(siteSettings)
     .values([
       {
-        key: "banner_enabled",
+        key: BANNER_SETTING_KEYS.enabled,
         value: enabled ? "true" : "false",
         updatedAt: now,
       },
-      { key: "banner_message", value: message, updatedAt: now },
-      { key: "banner_href", value: href, updatedAt: now },
+      { key: BANNER_SETTING_KEYS.message, value: message, updatedAt: now },
+      { key: BANNER_SETTING_KEYS.href, value: href, updatedAt: now },
     ])
     .onConflictDoUpdate({
       target: siteSettings.key,

--- a/lib/db/queries/settings.ts
+++ b/lib/db/queries/settings.ts
@@ -1,7 +1,9 @@
-import { inArray } from "drizzle-orm";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
+import { unstable_cache } from "next/cache";
 import { db } from "@/lib/db";
 import { siteSettings } from "@/lib/db/schema";
+
+export const BANNER_CACHE_TAG = "banner";
 
 export async function getSiteSetting(key: string): Promise<string | null> {
   try {
@@ -42,15 +44,21 @@ export interface BannerConfig {
   href: string;
 }
 
-export async function getBannerConfig(): Promise<BannerConfig> {
-  const rows = await getSiteSettings([
-    "banner_enabled",
-    "banner_message",
-    "banner_href",
-  ]);
-  return {
-    enabled: rows.banner_enabled === "true",
-    message: rows.banner_message ?? "",
-    href: rows.banner_href ?? "",
-  };
-}
+// Cached because the banner renders in the root layout — a naive read would
+// hit the DB on every request site-wide. Tag-invalidated by setBannerConfig.
+export const getBannerConfig = unstable_cache(
+  async (): Promise<BannerConfig> => {
+    const rows = await getSiteSettings([
+      "banner_enabled",
+      "banner_message",
+      "banner_href",
+    ]);
+    return {
+      enabled: rows.banner_enabled === "true",
+      message: rows.banner_message ?? "",
+      href: rows.banner_href ?? "",
+    };
+  },
+  ["banner-config"],
+  { tags: [BANNER_CACHE_TAG] },
+);

--- a/lib/db/queries/settings.ts
+++ b/lib/db/queries/settings.ts
@@ -5,6 +5,12 @@ import { siteSettings } from "@/lib/db/schema";
 
 export const BANNER_CACHE_TAG = "banner";
 
+export const BANNER_SETTING_KEYS = {
+  enabled: "banner_enabled",
+  message: "banner_message",
+  href: "banner_href",
+} as const;
+
 export async function getSiteSetting(key: string): Promise<string | null> {
   try {
     const result = await db
@@ -48,15 +54,11 @@ export interface BannerConfig {
 // hit the DB on every request site-wide. Tag-invalidated by setBannerConfig.
 export const getBannerConfig = unstable_cache(
   async (): Promise<BannerConfig> => {
-    const rows = await getSiteSettings([
-      "banner_enabled",
-      "banner_message",
-      "banner_href",
-    ]);
+    const rows = await getSiteSettings(Object.values(BANNER_SETTING_KEYS));
     return {
-      enabled: rows.banner_enabled === "true",
-      message: rows.banner_message ?? "",
-      href: rows.banner_href ?? "",
+      enabled: rows[BANNER_SETTING_KEYS.enabled] === "true",
+      message: rows[BANNER_SETTING_KEYS.message] ?? "",
+      href: rows[BANNER_SETTING_KEYS.href] ?? "",
     };
   },
   ["banner-config"],

--- a/lib/db/queries/settings.ts
+++ b/lib/db/queries/settings.ts
@@ -1,3 +1,4 @@
+import { inArray } from "drizzle-orm";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { siteSettings } from "@/lib/db/schema";
@@ -16,7 +17,40 @@ export async function getSiteSetting(key: string): Promise<string | null> {
   }
 }
 
+async function getSiteSettings(
+  keys: string[],
+): Promise<Record<string, string>> {
+  try {
+    const rows = await db
+      .select({ key: siteSettings.key, value: siteSettings.value })
+      .from(siteSettings)
+      .where(inArray(siteSettings.key, keys));
+    return Object.fromEntries(rows.map((r) => [r.key, r.value]));
+  } catch {
+    return {};
+  }
+}
+
 export async function getHomepagePhase(): Promise<1 | 2> {
   const value = await getSiteSetting("homepage_phase");
   return value === "2" ? 2 : 1;
+}
+
+export interface BannerConfig {
+  enabled: boolean;
+  message: string;
+  href: string;
+}
+
+export async function getBannerConfig(): Promise<BannerConfig> {
+  const rows = await getSiteSettings([
+    "banner_enabled",
+    "banner_message",
+    "banner_href",
+  ]);
+  return {
+    enabled: rows.banner_enabled === "true",
+    message: rows.banner_message ?? "",
+    href: rows.banner_href ?? "",
+  };
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,6 +4,9 @@ import { vi } from "vitest";
 // Mock next/cache — used by all server actions
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  updateTag: vi.fn(),
+  unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
 }));
 
 // Mock next/navigation — redirect() throws in Next.js


### PR DESCRIPTION
## Summary
- Site banner is now admin-editable via Settings → Site Banner (enabled toggle, message, optional https link). Previously hardcoded for the Seed Pitch Night.
- NPC Festival (April 25) marked as cancelled due to weather on /about — struck through with a red label.
- Banner reads are cached (unstable_cache + \`BANNER_CACHE_TAG\`) so the layout-wide render doesn't hit the DB per request; \`setBannerConfig\` calls \`updateTag\` after a save.
- \`setBannerConfig\` validates input with Zod: 200-char message cap, https-only URL (rejects \`javascript:\`, \`http:\`, malformed). Returns \`{success: false, error}\` on invalid input.
- Three per-key upserts collapsed into a single multi-row \`INSERT ... ON CONFLICT DO UPDATE SET value = excluded.value\` — all three keys land atomically.

## Test plan
- [ ] Visit /admin → Settings → Site Banner: enable, set a message + https URL, Save. Confirm banner appears site-wide and that the layout renders fresh on next request.
- [ ] Disable the banner and confirm it disappears everywhere.
- [ ] Try saving with \`javascript:alert(1)\` or \`http://example.com\` — should show an error toast, no DB write.
- [ ] Try a message > 200 chars — should error.
- [ ] Visit /about and confirm the NPC Festival row has strikethrough + "Cancelled due to weather".
- [ ] \`pnpm test:run && pnpm lint && pnpm exec tsc --noEmit\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)