### PR TITLE
Open seed images in a lightbox instead of a new tab

### DIFF
--- a/app/seeds/[id]/page.tsx
+++ b/app/seeds/[id]/page.tsx
@@ -203,21 +203,22 @@ export default async function SeedPage(props: {
 
         {/* Image — top right on desktop, below on mobile */}
         <div className="flex flex-col gap-4">
-          {seed.coverPhotoUrl ? (
-            <ImageLightbox
-              src={seed.coverPhotoUrl}
-              alt={seed.name}
-              sizes="(max-width: 768px) 100vw, 360px"
-              priority
-            />
-          ) : seed.imageUrl ? (
-            <ImageLightbox
-              src={seed.imageUrl}
-              alt={buildImagePrompt(seed)}
-              sizes="(max-width: 768px) 100vw, 360px"
-              priority
-            />
-          ) : null}
+          {(() => {
+            const hero = seed.coverPhotoUrl
+              ? { src: seed.coverPhotoUrl, alt: seed.name }
+              : seed.imageUrl
+                ? { src: seed.imageUrl, alt: buildImagePrompt(seed) }
+                : null;
+            if (!hero) return null;
+            return (
+              <ImageLightbox
+                src={hero.src}
+                alt={hero.alt}
+                sizes="(max-width: 768px) 100vw, 360px"
+                priority
+              />
+            );
+          })()}
           {/* Always generate AI illustration if missing, even when cover photo is set */}
           {!seed.imageUrl && canEdit && <SeedImageGenerator seedId={seed.id} />}
         </div>

--- a/app/seeds/[id]/page.tsx
+++ b/app/seeds/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from "next/navigation";
-import Image from "next/image";
 import Link from "next/link";
 import { Mail, Pencil, QrCode, Sun } from "lucide-react";
 import { SeedIcon, type SeedIconName } from "@/components/icons/seed-icons";
@@ -12,6 +11,7 @@ import { Separator } from "@/components/ui/separator";
 import { CategoryBadge } from "@/components/seeds/category-badge";
 import { SeedStatusBadge } from "@/components/dashboard/seed-status-badge";
 import { CommentsSection } from "@/components/seeds/comments-section";
+import { ImageLightbox } from "@/components/seeds/image-lightbox";
 import { SeedImageGenerator } from "@/components/seeds/seed-image-generator";
 import { SupportButton } from "@/components/seeds/support-button";
 import { ExpandableText } from "@/components/seeds/expandable-text";
@@ -204,39 +204,19 @@ export default async function SeedPage(props: {
         {/* Image — top right on desktop, below on mobile */}
         <div className="flex flex-col gap-4">
           {seed.coverPhotoUrl ? (
-            <a
-              href={seed.coverPhotoUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block overflow-hidden rounded-2xl"
-            >
-              <Image
-                src={seed.coverPhotoUrl}
-                alt={seed.name}
-                width={720}
-                height={720}
-                className="h-auto w-full"
-                sizes="(max-width: 768px) 100vw, 360px"
-                priority
-              />
-            </a>
+            <ImageLightbox
+              src={seed.coverPhotoUrl}
+              alt={seed.name}
+              sizes="(max-width: 768px) 100vw, 360px"
+              priority
+            />
           ) : seed.imageUrl ? (
-            <a
-              href={seed.imageUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block overflow-hidden rounded-2xl"
-            >
-              <Image
-                src={seed.imageUrl}
-                alt={buildImagePrompt(seed)}
-                width={720}
-                height={720}
-                className="h-auto w-full"
-                sizes="(max-width: 768px) 100vw, 360px"
-                priority
-              />
-            </a>
+            <ImageLightbox
+              src={seed.imageUrl}
+              alt={buildImagePrompt(seed)}
+              sizes="(max-width: 768px) 100vw, 360px"
+              priority
+            />
           ) : null}
           {/* Always generate AI illustration if missing, even when cover photo is set */}
           {!seed.imageUrl && canEdit && <SeedImageGenerator seedId={seed.id} />}
@@ -254,21 +234,18 @@ export default async function SeedPage(props: {
             <h3 className="mb-3 text-sm font-semibold">Photos</h3>
             <div className="grid grid-cols-3 gap-3">
               {displayPhotos.map((url, i) => (
-                <a
+                <div
                   key={url}
-                  href={url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="relative block aspect-square overflow-hidden rounded-lg"
+                  className="relative aspect-square overflow-hidden rounded-lg"
                 >
-                  <Image
+                  <ImageLightbox
                     src={url}
                     alt={`${seed.name} photo ${i + 1}`}
                     fill
-                    className="object-cover"
                     sizes="(max-width: 768px) 33vw, 280px"
+                    triggerClassName="absolute inset-0"
                   />
-                </a>
+                </div>
               ))}
             </div>
           </div>
@@ -401,21 +378,14 @@ export default async function SeedPage(props: {
       {/* AI illustration — shown at bottom when a user photo is the cover */}
       {seed.coverPhotoUrl && seed.imageUrl && (
         <div className="mt-12 flex justify-center">
-          <a
-            href={seed.imageUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block max-w-xs overflow-hidden rounded-2xl"
-          >
-            <Image
-              src={seed.imageUrl}
-              alt={`${seed.name} illustration`}
-              width={360}
-              height={480}
-              className="h-auto w-full"
-              sizes="320px"
-            />
-          </a>
+          <ImageLightbox
+            src={seed.imageUrl}
+            alt={`${seed.name} illustration`}
+            thumbWidth={360}
+            thumbHeight={480}
+            sizes="320px"
+            triggerClassName="max-w-xs"
+          />
         </div>
       )}
     </div>

--- a/components/seeds/image-lightbox.tsx
+++ b/components/seeds/image-lightbox.tsx
@@ -72,23 +72,22 @@ export function ImageLightbox({
       </DialogTrigger>
       <DialogContent
         showCloseButton={false}
-        className="max-w-[95vw] border-0 bg-transparent p-0 shadow-none sm:max-w-[95vw]"
+        className="w-fit max-w-[95vw] border-0 bg-transparent p-0 shadow-none sm:max-w-[95vw]"
       >
         <DialogTitle className="sr-only">{alt}</DialogTitle>
-        <DialogClose
-          className="absolute top-3 right-3 z-10 rounded-full bg-black/60 p-2 text-white transition hover:bg-black/80 focus:ring-2 focus:ring-white focus:outline-none"
-          aria-label="Close"
-        >
-          <X className="size-5" />
-        </DialogClose>
-        <div className="relative h-[90vh] w-full">
-          <Image
+        <div className="relative">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
             src={src}
             alt={alt}
-            fill
-            sizes="95vw"
-            className="object-contain"
+            className="block max-h-[90vh] max-w-[95vw] rounded"
           />
+          <DialogClose
+            className="absolute top-2 right-2 z-10 rounded-full bg-black/60 p-2 text-white transition hover:bg-black/80 focus:ring-2 focus:ring-white focus:outline-none"
+            aria-label="Close"
+          >
+            <X className="size-5" />
+          </DialogClose>
         </div>
       </DialogContent>
     </Dialog>

--- a/components/seeds/image-lightbox.tsx
+++ b/components/seeds/image-lightbox.tsx
@@ -42,7 +42,7 @@ export function ImageLightbox({
         <button
           type="button"
           className={cn(
-            "group block cursor-zoom-in overflow-hidden",
+            "block cursor-zoom-in overflow-hidden",
             !fill && "rounded-2xl",
             triggerClassName,
           )}
@@ -79,7 +79,7 @@ export function ImageLightbox({
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={src}
-            alt={alt}
+            alt=""
             className="block max-h-[90vh] max-w-[95vw] rounded"
           />
           <DialogClose

--- a/components/seeds/image-lightbox.tsx
+++ b/components/seeds/image-lightbox.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Image from "next/image";
+import { X } from "lucide-react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface ImageLightboxProps {
+  src: string;
+  alt: string;
+  thumbWidth?: number;
+  thumbHeight?: number;
+  thumbClassName?: string;
+  sizes?: string;
+  priority?: boolean;
+  /** Wrapper class for the trigger; defaults to rounded-2xl */
+  triggerClassName?: string;
+  /** Use `fill` on the thumbnail (parent must be positioned) */
+  fill?: boolean;
+}
+
+export function ImageLightbox({
+  src,
+  alt,
+  thumbWidth = 720,
+  thumbHeight = 720,
+  thumbClassName,
+  sizes,
+  priority,
+  triggerClassName,
+  fill,
+}: ImageLightboxProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "group block cursor-zoom-in overflow-hidden",
+            !fill && "rounded-2xl",
+            triggerClassName,
+          )}
+          aria-label={`Open ${alt}`}
+        >
+          {fill ? (
+            <Image
+              src={src}
+              alt={alt}
+              fill
+              className={cn("object-cover", thumbClassName)}
+              sizes={sizes}
+              priority={priority}
+            />
+          ) : (
+            <Image
+              src={src}
+              alt={alt}
+              width={thumbWidth}
+              height={thumbHeight}
+              className={cn("h-auto w-full", thumbClassName)}
+              sizes={sizes}
+              priority={priority}
+            />
+          )}
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-[95vw] border-0 bg-transparent p-0 shadow-none sm:max-w-[95vw]"
+      >
+        <DialogTitle className="sr-only">{alt}</DialogTitle>
+        <DialogClose
+          className="absolute top-3 right-3 z-10 rounded-full bg-black/60 p-2 text-white transition hover:bg-black/80 focus:ring-2 focus:ring-white focus:outline-none"
+          aria-label="Close"
+        >
+          <X className="size-5" />
+        </DialogClose>
+        <div className="relative h-[90vh] w-full">
+          <Image
+            src={src}
+            alt={alt}
+            fill
+            sizes="95vw"
+            className="object-contain"
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- New \`ImageLightbox\` client component (shadcn Dialog) replaces four \`target=\"_blank\"\` anchor wrappers on the seed detail page.
- Click a thumbnail → image opens in a modal centered at up to 95vw × 90vh; X button overlays the top-right corner of the image itself.
- Clicking anywhere outside the image (overlay) or pressing ESC closes the modal.
- Thumbnails keep next/image optimization; modal uses a plain \`<img>\` so the content box shrink-wraps to the image's actual aspect, letting the X sit on the image corner.

## Test plan
- [x] Visit a seed with a cover photo — click the cover, verify lightbox opens centered, X in top-right of the image, ESC closes.
- [x] Click outside the image (dark area) — closes.
- [x] Same flow on a seed with an AI illustration (no cover photo).
- [x] Click any thumbnail in the photo grid — verify fill-mode trigger opens the correct full image.
- [ ] Secondary AI illustration (when both cover and AI exist) — verify it also opens.
- [ ] \`pnpm test:run && pnpm lint && pnpm exec tsc --noEmit\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)